### PR TITLE
Make upload_images resumable by moving files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ bucket, run the helper binary:
 ```bash
 cargo run --bin upload_images
 ```
+
+Uploaded files are moved to `UPLOADED_DIR` (defaults to `IMAGES_DIR/uploaded`)
+so rerunning the command continues from the remaining images.

--- a/src/bin/upload_images.rs
+++ b/src/bin/upload_images.rs
@@ -1,20 +1,27 @@
-use std::{env, fs};
+use std::{env, fs, path::Path};
 
 use dotenvy::dotenv;
 
-#[path = "../s3.rs"]
-mod s3;
 #[path = "../error.rs"]
 mod error;
+#[path = "../s3.rs"]
+mod s3;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
     let images_dir = env::var("IMAGES_DIR")?;
+    let uploaded_dir = env::var("UPLOADED_DIR").unwrap_or_else(|_| {
+        Path::new(&images_dir)
+            .join("uploaded")
+            .to_string_lossy()
+            .into_owned()
+    });
+    fs::create_dir_all(&uploaded_dir)?;
     for entry in fs::read_dir(&images_dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) == Some("jpg") {
+        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("jpg") {
             let id = match path.file_stem().and_then(|s| s.to_str()) {
                 Some(s) => s,
                 None => {
@@ -24,7 +31,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             match fs::read(&path) {
                 Ok(data) => match s3::upload_image(id, data).await {
-                    Ok(_) => println!("Uploaded {}", id),
+                    Ok(_) => {
+                        println!("Uploaded {}", id);
+                        if let Some(filename) = path.file_name() {
+                            if let Err(e) =
+                                fs::rename(&path, Path::new(&uploaded_dir).join(filename))
+                            {
+                                eprintln!("Failed to move {}: {}", id, e);
+                            }
+                        }
+                    }
                     Err(e) => eprintln!("Failed to upload {}: {}", id, e),
                 },
                 Err(e) => eprintln!("Failed to read {:?}: {}", path, e),
@@ -33,4 +49,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     Ok(())
 }
-


### PR DESCRIPTION
## Summary
- move uploaded images to a configurable `UPLOADED_DIR`
- document resumable uploads in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b0706e3bd88320958c3180e2d96350